### PR TITLE
[RT-1291] Modification of delete groups API response

### DIFF
--- a/rest_api/v2/paths/groups/delete.yml
+++ b/rest_api/v2/paths/groups/delete.yml
@@ -18,8 +18,9 @@ responses:
           properties:
             group_id:
               $ref: '../../components/index.yml#/schemas/GroupId'
-            parent_id:
-              $ref: '../../components/index.yml#/schemas/GroupParentId'
+            status:
+              type: string
+              enum: ["success"]
   401:
     $ref: '../../components/index.yml#/responses/401'
   403:

--- a/rest_api/v2/paths/groups/delete.yml
+++ b/rest_api/v2/paths/groups/delete.yml
@@ -16,7 +16,7 @@ responses:
           description: Response object
           type: object
           properties:
-            group_id:
+            id:
               $ref: '../../components/index.yml#/schemas/GroupId'
             status:
               type: string

--- a/rest_api/v2/paths/groups/get.yml
+++ b/rest_api/v2/paths/groups/get.yml
@@ -4,6 +4,19 @@ operationId: getGroups
 summary: Get groups
 description: >
   This endpoint returns all the information about the groups that the user has access to.
+
+requestBody:
+  required: false
+  content:
+    application/json:
+      schema:
+        description: Request body to search groups
+        type: object
+        properties:
+          name__contains:
+            description: Perform a fuzzy search on groups
+            type: string
+            example: "ComfyZone"
 responses:
   200:
     description: OK


### PR DESCRIPTION
As a developer when I call the api/v2/groups/id with Delete I expect to have a response:

{
  "id": 123,
  "status": "success",
}
Then the Front-end needs to be adapted to get the information about the group parent id from it’s own resources.

Update the documentation   