### PR TITLE
Fix groups and business

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 .vscode/
 .idea/
+package-lock.json

--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -547,7 +547,7 @@ schemas:
         $ref: '#/schemas/GroupName'
       provider:
         $ref: '#/schemas/GroupProvider'
-      subgroup:
+      subgroups:
         description: Subgroups of the group. A subgroup can not have subgroups
         type: array
   Group_with_subgroup:
@@ -1239,6 +1239,13 @@ parameters:
       type: integer
       default: 0
     description: Page number. 30 results per page
+  query_page_100:
+    in: query
+    name: page
+    schema:
+      type: integer
+      default: 1
+    description: Page number. Starts at 1. 100 results per page.
   query_org_id:
     in: query
     name: org_id

--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -444,7 +444,7 @@ schemas:
   BusinessZipcode:
     description: Business zipcode
     type: string
-    example: 75019
+    example: "75019"
   BusinessNationalIdentificationNumber:
     description: Business National Identification number
     type: string
@@ -931,7 +931,7 @@ schemas:
       number:
         description: Street number
         type: string
-        example: 12
+        example: "12"
       number_supplement:
         description: Street number supplement
         type: string

--- a/rest_api/v2/paths/groups/get.yml
+++ b/rest_api/v2/paths/groups/get.yml
@@ -4,19 +4,15 @@ operationId: getGroups
 summary: Get groups
 description: >
   This endpoint returns all the information about the groups that the user has access to.
-
-requestBody:
-  required: false
-  content:
-    application/json:
-      schema:
-        description: Request body to search groups
-        type: object
-        properties:
-          name__contains:
-            description: Perform a fuzzy search on groups
-            type: string
-            example: "ComfyZone"
+parameters:
+  - in: query
+    name: name__contains
+    schema:
+      type: string
+    description: Perform a fuzzy search on the group names
+    required: false
+    example: "bakery"
+  - $ref: '../../components/index.yml#/parameters/query_page_100'
 responses:
   200:
     description: OK

--- a/rest_api/v2/paths/groups/post.yml
+++ b/rest_api/v2/paths/groups/post.yml
@@ -25,10 +25,7 @@ responses:
     content:
       application/json:
         schema:
-          type: object
-          properties:
-            group:
-              $ref: '../../components/index.yml#/schemas/Group'
+          $ref: '../../components/index.yml#/schemas/Group_with_subgroup'
   400:
     $ref: '../../components/index.yml#/responses/400'
   401:

--- a/rest_api/v2/paths/groups/update.yml
+++ b/rest_api/v2/paths/groups/update.yml
@@ -23,10 +23,7 @@ responses:
     content:
       application/json:
         schema:
-          type: object
-          properties:
-            group:
-              $ref: '../../components/index.yml#/schemas/Group'
+          $ref: '../../components/index.yml#/schemas/Group_with_subgroup'
   400:
     $ref: '../../components/index.yml#/responses/400'
   401:


### PR DESCRIPTION
We got a client that complained that the doc was incorrect. Here are the different things he made as feedback (with the answers I gave him)

1. Search dans les groupes ineffectif
=> En effet, le search ne marche pas lorsque l'on passe le filtre dans le body. Vous pouvez cependant aussi passer le paramètre dans l'url, comme https://sandbox.partoo.co/api/v2/groups?name__contains=test. Et la cela fonctionne. Nous allons mettre à jour la doc.

2. Pagination non documentée pour les groupes
=> Vous pouvez ajouter le paramètre page=N pour faire la pagination, comme https://sandbox.partoo.co/api/v2/groups?page=1. Il faut savoir que la pagination commence à 1. Et il y a actuellement un soucis dans la réponse, ou si l'on demande la page 3, le payload réponse indiquera "page: 2". Nous allons mettre à jour la documentation.

3. Création de groupe (POST) et mise à jour de groupe (PUT), l'objet retourné est directement le groupe
=> En effet, nous allons mettre à jour la documentation.

4. Zipcode et Number qui sont des strings au lieu d'entiers lors de la création d'un Business.
=> Oui, la liste de mises à jour s'agrandit !
