### PR TITLE
Add lang in user schema and create_user doc

### DIFF
--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -260,6 +260,7 @@ schemas:
       - en
       - es
       - it
+      - pt-br
     example: fr
   UserStatus:
     description: User status in the application

--- a/rest_api/v2/paths/user/post.yml
+++ b/rest_api/v2/paths/user/post.yml
@@ -53,6 +53,8 @@ requestBody:
             default: "False"
           password:
             $ref: '../../components/index.yml#/schemas/Password'
+          lang:
+            $ref: '../../components/index.yml#/schemas/Lang'
 responses:
   200:
     description: OK


### PR DESCRIPTION
Seen with Savinien
https://developers.partoo.co/rest_api/v2/#operation/getMyUser : Ajouter la langue "pt-br" dans le paramètre lang
 https://developers.partoo.co/rest_api/v2/#operation/createUser : Rajouter lang dans la création du user