### PR TITLE
[RT-1730] - [Apple documentation] Put as Deprecated the Clean name

### DIFF
--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -479,7 +479,8 @@ schemas:
     minLength: 1
     example: Corner shop
   BusinessCleanName:
-    description: ❗This field will be soon mandatory. <br />The clean name of the business (typically the brand name) used for Apple, Foursquare and Justacote (french only) partners. This should not contain the city name nor any additional descriptive items
+    deprecated: True
+    description: <code>It will be removed in November 2020</code> <br />The clean name of the business (typically the brand name) used for Apple, Foursquare and Justacote (french only) partners. This should not contain the city name nor any additional descriptive items
     type: string
     minLength: 1
     examples: Partoo
@@ -1967,7 +1968,8 @@ parameters:
     schema:
       type: string
     required: false
-    description: Filter by clean name
+    deprecated: true
+    description:  <p><code>It will be removed in November 2020</code>. Filter by clean name.</p>
   query_filter_by_country:
     in: query
     name: country


### PR DESCRIPTION
Clean name section for Search: 
<img width="669" alt="Screen Shot 2020-08-26 at 11 01 39" src="https://user-images.githubusercontent.com/16220249/91284541-4e1a3700-e78c-11ea-8738-f484d1776e3f.png">

Clean name section for Create, Update and Get:
<img width="667" alt="Screen Shot 2020-08-26 at 10 53 16" src="https://user-images.githubusercontent.com/16220249/91284616-7013b980-e78c-11ea-984c-efe73c200004.png">

