### PR TITLE
[BPT-798] Add the Google Post documentation in the Partoo REST API 

### DIFF
--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -1695,6 +1695,199 @@ schemas:
           This value must be used within the placeholder markup `@[](placeholder_value)` in a template `text` in order to work properly.
         example: "my_first_name"
 
+  GooglePostId:
+    description: Google Post id
+    type: integer
+    example: 34
+
+  GooglePostTopicType:
+    description: Topic type of the google post, news/event/offer
+    type: string
+    example: news
+
+  GooglePostSummary:
+    description: Summary of the google post
+    type: string
+    example: You're business will now open until 20pm
+
+  GooglePostMediaUrl:
+    description: Url of the photo of the google post
+    type: string
+    example: https://www.my-photo.jpeg
+
+  GooglePostCallToActionType:
+    description: Button you want to put on the google post, book/order/shop/learn_more/sign_up/call/no_cta
+    type: string
+    example: no_cta
+
+  GooglePostCallToActionUrl:
+    description: Url that will be used for redirection when clicking on the call to action button.
+      In case of call or no_cta call_to_action_type, no call_to_action_url is needed.
+    type: string
+    example: https://www.partoo.co
+
+  GooglePostScheduledStartTime:
+    description: Date of publication of the google post
+    type: string
+    example: 2020-01-01T12:00:00+02:00
+
+  GooglePostTitle:
+    description: Name of the event
+    type: string
+    example: Big sales
+
+  GooglePostStartDatetime:
+    description: Event start time
+    type: string
+    example: 2020-01-02T12:00:00+02:00
+
+  GooglePostEndDatetime:
+    description: Event end time
+    type: string
+    example: 2020-01-015T12:00:00+02:00
+
+  GooglePostCouponCode:
+    description: Offer code that is usable in store or online
+    type: string
+    example: PROMO25
+
+  GooglePostRedeemOnlineUrl:
+    description: Online link to redeem offer
+    type: string
+    example: https://www.partoo.co
+
+  GooglePostTermsConditions:
+    description: Terms and conditions of the offer
+    type: string
+    example: These are the conditions
+
+  GooglePostEvent:
+    description: Google Post Event, required only for topic type event and offer
+    type: object
+    required:
+      - title
+      - start_datetime
+      - end_datetime
+    properties:
+      title:
+        $ref: '#/schemas/GooglePostTitle'
+      start_datetime:
+        $ref: '#/schemas/GooglePostStartDatetime'
+      end_datetime:
+        $ref: '#/schemas/GooglePostEndDatetime'
+
+  GooglePostOffer:
+    description: Google Post Offer, required only for topic type offer
+    type: object
+    properties:
+      coupon_code:
+        $ref: '#/schemas/GooglePostCouponCode'
+      redeem_online_url:
+        $ref: '#/schemas/GooglePostRedeemOnlineUrl'
+      terms_conditions:
+        $ref: '#/schemas/GooglePostTermsConditions'
+
+  GooglePostMediaFormat:
+    description: type of the media, can only be of type PHOTO
+    type: string
+    example: PHOTO
+
+  GooglePostMedia:
+    description: Media
+    type: object
+    properties:
+      media_url:
+        $ref: '#/schemas/GooglePostMediaUrl'
+      media_format:
+        $ref: '#/schemas/GooglePostMediaFormat'
+
+  GooglePostLanguageCode:
+    description: The language of the google post
+    type: string
+
+  GooglePostViewCount:
+    description: The number of times the local post was viewed on Google Search
+    type: integer
+    example: 200
+
+  GooglePostClickCount:
+    description: The number of times the local post was viewed on Google Search
+    type: integer
+    example: 155
+
+  GooglePostState:
+    description: The state of the post, indicating what part of its lifecycle it is in
+    type: string
+    example: pending
+
+  GooglePostCreatedOnPartoo:
+    description: Whether or not the post was created on partoo
+    type: boolean
+
+  GooglePostUpdatedOnPartoo:
+    description: Whether or not the post was updated on partoo
+    type: boolean
+
+  GooglePostSearchUrl:
+    description: The link to the local post in Google search
+    type: string
+
+  GooglePostBusinessInfo:
+    description: The name and address of the business
+    type: string
+
+  GooglePostGoogleCreationDate:
+    description: Time of the creation of the post on Google
+    type: string
+
+  GooglePostIsExpired:
+    description: Whether or not the post is expired
+    type: boolean
+
+  GooglePost:
+    description: Google Post
+    type: object
+    properties:
+      id:
+        $ref: '#/schemas/GooglePostId'
+      business_id:
+        $ref: '#/schemas/BusinessId'
+      topic_type:
+        $ref: '#/schemas/GooglePostTopicType'
+      summary:
+        $ref: '#/schemas/GooglePostSummary'
+      scheduled_start_time:
+        $ref: '#/schemas/GooglePostScheduledStartTime'
+      google_post_event:
+        $ref: '#/schemas/GooglePostEvent'
+      google_post_offer:
+        $ref: '#/schemas/GooglePostOffer'
+      google_post_media:
+        $ref: '#/schemas/GooglePostMedia'
+      created_at:
+        $ref: '#/schemas/CreatedDate'
+      updated_at:
+        $ref: '#/schemas/UpdatedDate'
+      language_code:
+        $ref: '#/schemas/GooglePostLanguageCode'
+      view_count:
+        $ref: '#/schemas/GooglePostViewCount'
+      click_count:
+        $ref: '#/schemas/GooglePostClickCount'
+      state:
+        $ref: '#/schemas/GooglePostState'
+      created_on_partoo:
+        $ref: '#/schemas/GooglePostCreatedOnPartoo'
+      updated_on_partoo:
+        $ref: '#/schemas/GooglePostUpdatedOnPartoo'
+      search_url:
+        $ref: '#/schemas/GooglePostSearchUrl'
+      business_info:
+        $ref: '#/schemas/GooglePostBusinessInfo'
+      google_creation_date:
+        $ref: '#/schemas/GooglePostGoogleCreationDate'
+      is_expired:
+        $ref: '#/schemas/GooglePostIsExpired'
 
   # DEPRECATED fields
   Promo:
@@ -2189,6 +2382,48 @@ parameters:
       type: string
     required: false
     description: Filter on templates based on their text
+  path_google_post_id:
+    in: path
+    name: google_post_id
+    required: true
+    schema:
+      type: number
+    description: Google Post id
+  query_google_post_title_query:
+    in: query
+    name: title_query
+    schema:
+      type: string
+    required: false
+    description: Filter google post based on their title
+  query_google_post_summary_query:
+    in: query
+    name: summary_query
+    schema:
+      type: string
+    required: false
+    description: Filter google post based on their summary
+  query_google_post_start_datetime:
+    in: query
+    name: start_datetime
+    schema:
+      type: string
+    required: false
+    description: Filter google post based on their start time
+  query_google_post_end_datetime:
+    in: query
+    name: end_datetime
+    schema:
+      type: string
+    required: false
+    description: Filter google post based on their end time
+  query_google_post_is_expired:
+    in: query
+    name: is_expired
+    schema:
+      type: boolean
+    required: false
+    description: Filter google post based on whether or not it is expired
 responses:
   400:
     description: Your request is incorrect

--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -1708,7 +1708,7 @@ schemas:
   GooglePostSummary:
     description: Summary of the google post
     type: string
-    example: You're business will now open until 20pm
+    example: Your business will now open until 20:00
 
   GooglePostMediaUrl:
     description: Url of the photo of the google post
@@ -1727,7 +1727,8 @@ schemas:
     example: https://www.partoo.co
 
   GooglePostScheduledStartTime:
-    description: Date of publication of the google post
+    description: if you don't want to publish it right away (will be publish immediatly by default).
+      The timezone is mandatory
     type: string
     example: 2020-01-01T12:00:00+02:00
 
@@ -1737,12 +1738,12 @@ schemas:
     example: Big sales
 
   GooglePostStartDatetime:
-    description: Event start time
+    description: Event start time. The timezone is mandatory
     type: string
     example: 2020-01-02T12:00:00+02:00
 
   GooglePostEndDatetime:
-    description: Event end time
+    description: Event end time. The timezone is mandatory
     type: string
     example: 2020-01-015T12:00:00+02:00
 
@@ -1762,7 +1763,7 @@ schemas:
     example: These are the conditions
 
   GooglePostEvent:
-    description: Google Post Event, required only for topic type event and offer
+    description: Google Post Event, required only for event and offer topic types
     type: object
     required:
       - title
@@ -1777,7 +1778,7 @@ schemas:
         $ref: '#/schemas/GooglePostEndDatetime'
 
   GooglePostOffer:
-    description: Google Post Offer, required only for topic type offer
+    description: Google Post Offer, required only for offer topic type
     type: object
     properties:
       coupon_code:

--- a/rest_api/v2/paths/google_post/create.yml
+++ b/rest_api/v2/paths/google_post/create.yml
@@ -1,0 +1,58 @@
+summary: Create a Google Post
+description: >
+  This endpoint lets you create a google post.
+operationId: createGooglePost
+tags:
+  - Google Post
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        description: Request body to create a google post
+        type: object
+        required:
+          - business_id
+          - topic_type
+          - summary
+          - google_post_event
+          - google_post_offer
+        properties:
+          business_id:
+            $ref: '../../components/index.yml#/schemas/BusinessId'
+          topic_type:
+            $ref: '../../components/index.yml#/schemas/GooglePostTopicType'
+          summary:
+            $ref: '../../components/index.yml#/schemas/GooglePostSummary'
+          media_url:
+            $ref: '../../components/index.yml#/schemas/GooglePostMediaUrl'
+          call_to_action_type:
+            $ref: '../../components/index.yml#/schemas/GooglePostCallToActionType'
+          call_to_action_url:
+            $ref: '../../components/index.yml#/schemas/GooglePostCallToActionUrl'
+          scheduled_start_time:
+            $ref: '../../components/index.yml#/schemas/GooglePostScheduledStartTime'
+          google_post_event:
+            $ref: '../../components/index.yml#/schemas/GooglePostEvent'
+          google_post_offer:
+            $ref: '../../components/index.yml#/schemas/GooglePostOffer'
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          description: Response object
+          type: object
+          properties:
+            status:
+              $ref: '../../components/index.yml#/schemas/RequestStatus'
+
+  401:
+    $ref: '../../components/index.yml#/responses/401'
+  403:
+    $ref: '../../components/index.yml#/responses/403'
+  404:
+    $ref: '../../components/index.yml#/responses/404'

--- a/rest_api/v2/paths/google_post/delete.yml
+++ b/rest_api/v2/paths/google_post/delete.yml
@@ -1,0 +1,28 @@
+summary: Delete a Google Post
+description: >
+  This endpoint lets you delete a google post.
+operationId: deleteGooglePost
+tags:
+  - Google Post
+
+
+parameters:
+      - $ref: '../../components/index.yml#/parameters/path_google_post_id'
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          description: Response object
+          type: object
+          properties:
+            status:
+              $ref: '../../components/index.yml#/schemas/RequestStatus'
+
+  401:
+    $ref: '../../components/index.yml#/responses/401'
+  403:
+    $ref: '../../components/index.yml#/responses/403'
+  404:
+    $ref: '../../components/index.yml#/responses/404'

--- a/rest_api/v2/paths/google_post/get.yml
+++ b/rest_api/v2/paths/google_post/get.yml
@@ -1,6 +1,6 @@
 summary: Get a specific Google Post
 description: >
-  This endpoint lets you  a google post.
+  This endpoint lets you access a google post.
 operationId: getGooglePost
 tags:
   - Google Post

--- a/rest_api/v2/paths/google_post/get.yml
+++ b/rest_api/v2/paths/google_post/get.yml
@@ -1,0 +1,24 @@
+summary: Get a specific Google Post
+description: >
+  This endpoint lets you  a google post.
+operationId: getGooglePost
+tags:
+  - Google Post
+
+parameters:
+      - $ref: '../../components/index.yml#/parameters/path_google_post_id'
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/index.yml#/schemas/GooglePost'
+
+  401:
+    $ref: '../../components/index.yml#/responses/401'
+  403:
+    $ref: '../../components/index.yml#/responses/403'
+  404:
+    $ref: '../../components/index.yml#/responses/404'

--- a/rest_api/v2/paths/google_post/search.yml
+++ b/rest_api/v2/paths/google_post/search.yml
@@ -1,0 +1,36 @@
+summary: Search Google Post
+description: >
+  This endpoint lets you browse through all your google posts.
+operationId: searchGooglePost
+tags:
+  - Google Post
+
+
+parameters:
+  - $ref: '../../components/index.yml#/parameters/query_business__in'
+  - $ref: '../../components/index.yml#/parameters/query_google_post_start_datetime'
+  - $ref: '../../components/index.yml#/parameters/query_google_post_end_datetime'
+  - $ref: '../../components/index.yml#/parameters/query_google_post_is_expired'
+  - $ref: '../../components/index.yml#/parameters/query_google_post_title_query'
+  - $ref: '../../components/index.yml#/parameters/query_google_post_summary_query'
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: '../../components/index.yml#/schemas/ListResult'
+            - type: object
+              properties:
+                google_post:
+                  type: array
+                  description: List of google post
+                  items:
+                    $ref: '../../components/index.yml#/schemas/GooglePost'
+  401:
+    $ref: '../../components/index.yml#/responses/401'
+  403:
+    $ref: '../../components/index.yml#/responses/403'
+  404:
+    $ref: '../../components/index.yml#/responses/404'

--- a/rest_api/v2/paths/google_post/update.yml
+++ b/rest_api/v2/paths/google_post/update.yml
@@ -1,0 +1,46 @@
+summary: Update a Google Post
+description: >
+  This endpoint lets you update a google post.
+operationId: updateGooglePost
+tags:
+  - Google Post
+
+parameters:
+      - $ref: '../../components/index.yml#/parameters/path_google_post_id'
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        description: Request body to update a google post
+        type: object
+        properties:
+          summary:
+            $ref: '../../components/index.yml#/schemas/GooglePostSummary'
+          media_url:
+            $ref: '../../components/index.yml#/schemas/GooglePostMediaUrl'
+          call_to_action_type:
+            $ref: '../../components/index.yml#/schemas/GooglePostCallToActionType'
+          call_to_action_url:
+            $ref: '../../components/index.yml#/schemas/GooglePostCallToActionUrl'
+          scheduled_start_time:
+            $ref: '../../components/index.yml#/schemas/GooglePostScheduledStartTime'
+          google_post_event:
+            $ref: '../../components/index.yml#/schemas/GooglePostEvent'
+          google_post_offer:
+            $ref: '../../components/index.yml#/schemas/GooglePostOffer'
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/index.yml#/schemas/GooglePost'
+
+  401:
+    $ref: '../../components/index.yml#/responses/401'
+  403:
+    $ref: '../../components/index.yml#/responses/403'
+  404:
+    $ref: '../../components/index.yml#/responses/404'

--- a/rest_api/v2/paths/index.yml
+++ b/rest_api/v2/paths/index.yml
@@ -59,6 +59,20 @@
   post:
     $ref: ./authorize/post_revoke.yml
 
+# GOOGLE POST endpoints
+/google_post:
+  get:
+    $ref: ./google_post/search.yml
+  post:
+    $ref: ./google_post/create.yml
+/google_post/{google_post_id}:
+  get:
+    $ref: ./google_post/get.yml
+  patch:
+    $ref: ./google_post/update.yml
+  delete:
+    $ref: ./google_post/delete.yml
+
 # REVIEWS endpoints
 /reviews:
   get:


### PR DESCRIPTION
As API user, when I go to the Partoo REST documentation, I see the Google Post endpoints documented

Faire la doc pour:

- Create
- Edit
- Search
- Get
- Delete