### PR TITLE
[MT-1454] Add timezone info on business opening hours

### DIFF
--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -961,7 +961,7 @@ schemas:
       $ref: '#/schemas/TimeWindow'
   OpenHours:
     description: |
-      <p>The opening hours of the business.
+      <p>The opening hours of the business in its timezone.
       <p>❗ This field is not mandatory, but if not provided then the business will not be pushed on some platforms (example: Google My Business). If provided, then a schedule needs to be sent for each day in particular
     type: object
     required:

--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -961,7 +961,7 @@ schemas:
       $ref: '#/schemas/TimeWindow'
   OpenHours:
     description: |
-      <p>The opening hours of the business in its timezone.
+      <p>The opening hours of the business (in its timezone).
       <p>❗ This field is not mandatory, but if not provided then the business will not be pushed on some platforms (example: Google My Business). If provided, then a schedule needs to be sent for each day in particular
     type: object
     required:
@@ -989,7 +989,7 @@ schemas:
         $ref: '#/schemas/Day'
   SpecificHours:
     description: |
-      <p>Exceptional opening or closing times for the business in its timezone.
+      <p>Exceptional opening or closing times for the business (in its timezone).
       <p>All exceptional days of the year, including temporerly closed, can be specified beforehand or on the go. For example:
       <ul>
        <li>Beforehand: bank holidays (like Christmas or Pentecôte)</li>

--- a/rest_api/v2/components/index.yml
+++ b/rest_api/v2/components/index.yml
@@ -989,7 +989,7 @@ schemas:
         $ref: '#/schemas/Day'
   SpecificHours:
     description: |
-      <p>Exceptional openning or closing times for the business
+      <p>Exceptional opening or closing times for the business in its timezone.
       <p>All exceptional days of the year, including temporerly closed, can be specified beforehand or on the go. For example:
       <ul>
        <li>Beforehand: bank holidays (like Christmas or Pentecôte)</li>


### PR DESCRIPTION
## Issue Summary

Description

On the rest api doc, on the opening hours and specific hours, on business get/search/create/update, add a sentence that says that the hours are in the timezone of the business.

## Context

- Link to Jira: [MT-1454]

## Organizational

- [x] I have marked myself as the "Assignee"
- [x] I have chosen the review tag and have requested one engineer to review my PR
- [] I checked all the acceptance criteria are matched.

## Test 

- [x] My code is fully tested
- [ ] _I didn't write any tests because ⚠️_:
   - _write here_

## Migration
- [ ] ⚠️**IMPORTANT FOR SQL MIGRATION TO AVOID CONFLICT IN MASTER** My PR is up to date with master

[MT-1454]: https://partoo.atlassian.net/browse/MT-1454